### PR TITLE
feat: add multipart/form-data support for file uploads

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/bin/api-generate
+++ b/bin/api-generate
@@ -38,6 +38,9 @@ $openApi = json_decode($ymlSrc, true);
 
 $printer = new Nette\PhpGenerator\PsrPrinter;
 
+// Track which endpoint classes need MultipartTrait for file uploads
+$classNeedsMultipart = [];
+
 $endpointNamespaceName = 'CedricZiel\MattermostPhp\Client\Endpoint';
 $modelNamespaceName = 'CedricZiel\MattermostPhp\Client\Model';
 $clientNamespaceName = 'CedricZiel\MattermostPhp';
@@ -404,6 +407,9 @@ foreach ($openApi['paths'] as $path => $pathSpec) {
         $optionalPathParameters = [];
         $optionalQueryParameters = [];
 
+        $isMultipartRequest = false;
+        $multipartFields = [];
+
         if (isset($methodSpec['requestBody'])) {
             $requestBody = $methodSpec['requestBody'];
             $requestBodyContent = $requestBody['content'];
@@ -419,6 +425,52 @@ foreach ($openApi['paths'] as $path => $pathSpec) {
 
                 $bodyParameters[] = (new Parameter('requestBody'))
                     ->setType($modelNamespaceName . '\\' . $requestBodyClass->getName());
+            }
+
+            // Handle multipart/form-data for file uploads
+            if (isset($requestBodyContent['multipart/form-data'])) {
+                $isMultipartRequest = true;
+                $multipartSchema = $requestBodyContent['multipart/form-data']['schema'] ?? [];
+                $requiredFields = $multipartSchema['required'] ?? [];
+
+                // Mark this class as needing MultipartTrait
+                $classNeedsMultipart[$class->getName()] = true;
+
+                if (isset($multipartSchema['properties'])) {
+                    foreach ($multipartSchema['properties'] as $fieldName => $fieldSpec) {
+                        if (false === \Nette\PhpGenerator\Helpers::isIdentifier($fieldName)) {
+                            continue;
+                        }
+
+                        $isRequired = in_array($fieldName, $requiredFields, true);
+                        $isBinary = isset($fieldSpec['format']) && $fieldSpec['format'] === 'binary';
+
+                        $multipartFields[] = [
+                            'name' => $fieldName,
+                            'binary' => $isBinary,
+                            'required' => $isRequired,
+                            'description' => $fieldSpec['description'] ?? null,
+                        ];
+
+                        $p = new Parameter($fieldName);
+
+                        if ($isBinary) {
+                            // Binary fields accept string (content), resource, or StreamInterface
+                            $p->setType('mixed');
+                            $p->setComment(($fieldSpec['description'] ?? 'File content') . ' (string|resource|\Psr\Http\Message\StreamInterface)');
+                        } else {
+                            $p->setType(mapParameterType($fieldSpec['type'] ?? 'string'));
+                            $p->setComment($fieldSpec['description'] ?? null);
+                        }
+
+                        $p->setNullable(!$isRequired);
+                        if (!$isRequired) {
+                            $p->setDefaultValue(null);
+                        }
+
+                        $bodyParameters[] = $p;
+                    }
+                }
             }
         }
 
@@ -462,7 +514,32 @@ foreach ($openApi['paths'] as $path => $pathSpec) {
             ->addBody('$request = $this->requestFactory->createRequest(\'' .strtoupper($httpMethod) . '\', $uri);')
             ->addBody('$request = $request->withHeader(\'Authorization\', \'Bearer \' . $this->token);');
 
-        if (count($bodyParameters) > 0) {
+        if ($isMultipartRequest && count($multipartFields) > 0) {
+            // Generate multipart form data construction
+            $method->addBody('');
+            $method->addBody('// Build multipart form data');
+            $method->addBody('$multipartFields = [];');
+
+            foreach ($multipartFields as $field) {
+                $fieldName = $field['name'];
+                $isBinary = $field['binary'];
+
+                if ($isBinary) {
+                    $method->addBody(sprintf('if ($%s !== null) {', $fieldName));
+                    $method->addBody(sprintf('    $multipartFields[\'%s\'] = [\'contents\' => $%s, \'filename\' => \'%s\'];', $fieldName, $fieldName, $fieldName));
+                    $method->addBody('}');
+                } else {
+                    $method->addBody(sprintf('if ($%s !== null) {', $fieldName));
+                    $method->addBody(sprintf('    $multipartFields[\'%s\'] = $%s;', $fieldName, $fieldName));
+                    $method->addBody('}');
+                }
+            }
+
+            $method->addBody('');
+            $method->addBody('$multipart = $this->createMultipartStream($multipartFields);');
+            $method->addBody('$request = $request->withHeader(\'Content-Type\', \'multipart/form-data; boundary=\' . $multipart[\'boundary\']);');
+            $method->addBody('$request = $request->withBody($multipart[\'stream\']);');
+        } elseif (count($bodyParameters) > 0) {
             $method->addBody('$request = $request->withBody($this->streamFactory->createStream(json_encode($requestBody) ?? \'\'));');
         }
 
@@ -568,6 +645,13 @@ foreach ($openApi['paths'] as $path => $pathSpec) {
         $method
             ->addBody('')
             ->addBody('return $this->mapResponse($response, $map);');
+    }
+}
+
+// Add MultipartTrait to endpoint classes that need it for file uploads
+foreach ($endpointNamespace->getClasses() as $genClass) {
+    if (isset($classNeedsMultipart[$genClass->getName()]) && $classNeedsMultipart[$genClass->getName()]) {
+        $genClass->addTrait(\CedricZiel\MattermostPhp\Client\MultipartTrait::class);
     }
 }
 

--- a/src/Client/Endpoint/BotsEndpoint.php
+++ b/src/Client/Endpoint/BotsEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class BotsEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -379,6 +380,8 @@ class BotsEndpoint
     public function setBotIconImage(
         /** Bot user ID */
         string $bot_user_id,
+        /** SVG icon image to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $image,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultInternalServerErrorResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -390,6 +393,16 @@ class BotsEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($image !== null) {
+            $multipartFields['image'] = ['contents' => $image, 'filename' => 'image'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/BrandEndpoint.php
+++ b/src/Client/Endpoint/BrandEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class BrandEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -69,6 +70,8 @@ class BrandEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadBrandImage(
+        /** The image to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $image,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -79,6 +82,16 @@ class BrandEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($image !== null) {
+            $multipartFields['image'] = ['contents' => $image, 'filename' => 'image'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/CloudEndpoint.php
+++ b/src/Client/Endpoint/CloudEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class CloudEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -143,6 +144,7 @@ class CloudEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function confirmCustomerPayment(
+        ?string $stripe_setup_intent_id = null,
     ): \CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -153,6 +155,16 @@ class CloudEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($stripe_setup_intent_id !== null) {
+            $multipartFields['stripe_setup_intent_id'] = $stripe_setup_intent_id;
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/EmojiEndpoint.php
+++ b/src/Client/Endpoint/EmojiEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class EmojiEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -39,6 +40,10 @@ class EmojiEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function createEmoji(
+        /** A file to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $image,
+        /** A JSON object containing a `name` field with the name of the emoji and a `creator_id` field with the id of the authenticated user. */
+        string $emoji,
     ): \CedricZiel\MattermostPhp\Client\Model\Emoji|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -49,6 +54,19 @@ class EmojiEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($image !== null) {
+            $multipartFields['image'] = ['contents' => $image, 'filename' => 'image'];
+        }
+        if ($emoji !== null) {
+            $multipartFields['emoji'] = $emoji;
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/FilesEndpoint.php
+++ b/src/Client/Endpoint/FilesEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class FilesEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -47,8 +48,12 @@ class FilesEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadFile(
+        /** A file to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $files = null,
         /** The ID of the channel that this file will be uploaded to */
         ?string $channel_id = null,
+        /** A unique identifier for the file that will be returned in the response */
+        ?string $client_ids = null,
         /** The name of the file to be uploaded */
         ?string $filename = null,
     ): \CedricZiel\MattermostPhp\Client\Model\UploadFileResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
@@ -63,6 +68,22 @@ class FilesEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($files !== null) {
+            $multipartFields['files'] = ['contents' => $files, 'filename' => 'files'];
+        }
+        if ($channel_id !== null) {
+            $multipartFields['channel_id'] = $channel_id;
+        }
+        if ($client_ids !== null) {
+            $multipartFields['client_ids'] = $client_ids;
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/LDAPEndpoint.php
+++ b/src/Client/Endpoint/LDAPEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class LDAPEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -134,6 +135,8 @@ class LDAPEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadLdapPublicCertificate(
+        /** The public certificate file (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $certificate,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -144,6 +147,16 @@ class LDAPEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($certificate !== null) {
+            $multipartFields['certificate'] = ['contents' => $certificate, 'filename' => 'certificate'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 
@@ -197,6 +210,8 @@ class LDAPEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadLdapPrivateCertificate(
+        /** The private key file (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $certificate,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -207,6 +222,16 @@ class LDAPEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($certificate !== null) {
+            $multipartFields['certificate'] = ['contents' => $certificate, 'filename' => 'certificate'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/PluginsEndpoint.php
+++ b/src/Client/Endpoint/PluginsEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class PluginsEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -42,6 +43,10 @@ class PluginsEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadPlugin(
+        /** The plugin image to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $plugin,
+        /** Set to 'true' to overwrite a previously installed plugin with the same ID, if any */
+        ?string $force = null,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -52,6 +57,19 @@ class PluginsEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($plugin !== null) {
+            $multipartFields['plugin'] = ['contents' => $plugin, 'filename' => 'plugin'];
+        }
+        if ($force !== null) {
+            $multipartFields['force'] = $force;
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/SAMLEndpoint.php
+++ b/src/Client/Endpoint/SAMLEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class SAMLEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -99,6 +100,8 @@ class SAMLEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadSamlIdpCertificate(
+        /** The IDP certificate file (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $certificate,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -109,6 +112,16 @@ class SAMLEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($certificate !== null) {
+            $multipartFields['certificate'] = ['contents' => $certificate, 'filename' => 'certificate'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 
@@ -162,6 +175,8 @@ class SAMLEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadSamlPublicCertificate(
+        /** The public certificate file (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $certificate,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -172,6 +187,16 @@ class SAMLEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($certificate !== null) {
+            $multipartFields['certificate'] = ['contents' => $certificate, 'filename' => 'certificate'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 
@@ -225,6 +250,8 @@ class SAMLEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadSamlPrivateCertificate(
+        /** The private key file (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $certificate,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -235,6 +262,16 @@ class SAMLEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($certificate !== null) {
+            $multipartFields['certificate'] = ['contents' => $certificate, 'filename' => 'certificate'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/SystemEndpoint.php
+++ b/src/Client/Endpoint/SystemEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class SystemEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -512,6 +513,8 @@ class SystemEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadLicenseFile(
+        /** The license to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $license,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -522,6 +525,16 @@ class SystemEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($license !== null) {
+            $multipartFields['license'] = ['contents' => $license, 'filename' => 'license'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/TeamsEndpoint.php
+++ b/src/Client/Endpoint/TeamsEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class TeamsEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -900,6 +901,8 @@ class TeamsEndpoint
     public function setTeamIcon(
         /** Team GUID */
         string $team_id,
+        /** The image to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $image,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultInternalServerErrorResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -911,6 +914,16 @@ class TeamsEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($image !== null) {
+            $multipartFields['image'] = ['contents' => $image, 'filename' => 'image'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 
@@ -1249,6 +1262,12 @@ class TeamsEndpoint
     public function importTeam(
         /** Team GUID */
         string $team_id,
+        /** A file to be uploaded in zip format. (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $file,
+        /** The size of the zip file to be imported. */
+        int $filesize,
+        /** String that defines from which application the team was exported to be imported into Mattermost. */
+        string $importFrom,
     ): \CedricZiel\MattermostPhp\Client\Model\ImportTeamResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -1260,6 +1279,22 @@ class TeamsEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($file !== null) {
+            $multipartFields['file'] = ['contents' => $file, 'filename' => 'file'];
+        }
+        if ($filesize !== null) {
+            $multipartFields['filesize'] = $filesize;
+        }
+        if ($importFrom !== null) {
+            $multipartFields['importFrom'] = $importFrom;
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 
@@ -1405,6 +1440,18 @@ class TeamsEndpoint
     public function searchFiles(
         /** Team GUID */
         string $team_id,
+        /** The search terms as inputed by the user. To search for files from a user include `from:someusername`, using a user's username. To search in a specific channel include `in:somechannel`, using the channel name (not the display name). To search for specific extensions included `ext:extension`. */
+        string $terms,
+        /** Set to true if an Or search should be performed vs an And search. */
+        bool $is_or_search,
+        /** Offset from UTC of user timezone for date searches. */
+        ?int $time_zone_offset = null,
+        /** Set to true if deleted channels should be included in the search. (archived channels) */
+        ?bool $include_deleted_channels = null,
+        /** The page to select. (Only works with Elasticsearch) */
+        ?int $page = null,
+        /** The number of posts per page. (Only works with Elasticsearch) */
+        ?int $per_page = null,
     ): \CedricZiel\MattermostPhp\Client\Model\FileInfoList|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -1416,6 +1463,31 @@ class TeamsEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($terms !== null) {
+            $multipartFields['terms'] = $terms;
+        }
+        if ($is_or_search !== null) {
+            $multipartFields['is_or_search'] = $is_or_search;
+        }
+        if ($time_zone_offset !== null) {
+            $multipartFields['time_zone_offset'] = $time_zone_offset;
+        }
+        if ($include_deleted_channels !== null) {
+            $multipartFields['include_deleted_channels'] = $include_deleted_channels;
+        }
+        if ($page !== null) {
+            $multipartFields['page'] = $page;
+        }
+        if ($per_page !== null) {
+            $multipartFields['per_page'] = $per_page;
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/Endpoint/UsersEndpoint.php
+++ b/src/Client/Endpoint/UsersEndpoint.php
@@ -5,6 +5,7 @@ namespace CedricZiel\MattermostPhp\Client\Endpoint;
 class UsersEndpoint
 {
     use \CedricZiel\MattermostPhp\Client\HttpClientTrait;
+    use \CedricZiel\MattermostPhp\Client\MultipartTrait;
 
     public function __construct(
         protected string $baseUrl,
@@ -897,6 +898,8 @@ class UsersEndpoint
     public function setProfileImage(
         /** User GUID */
         string $user_id,
+        /** The image to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
+        mixed $image,
     ): \CedricZiel\MattermostPhp\Client\Model\StatusOK|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotFoundResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -908,6 +911,16 @@ class UsersEndpoint
 
         $request = $this->requestFactory->createRequest('POST', $uri);
         $request = $request->withHeader('Authorization', 'Bearer ' . $this->token);
+
+        // Build multipart form data
+        $multipartFields = [];
+        if ($image !== null) {
+            $multipartFields['image'] = ['contents' => $image, 'filename' => 'image'];
+        }
+
+        $multipart = $this->createMultipartStream($multipartFields);
+        $request = $request->withHeader('Content-Type', 'multipart/form-data; boundary=' . $multipart['boundary']);
+        $request = $request->withBody($multipart['stream']);
 
         $response = $this->httpClient->sendRequest($request);
 

--- a/src/Client/MultipartTrait.php
+++ b/src/Client/MultipartTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace CedricZiel\MattermostPhp\Client;
+
+use GuzzleHttp\Psr7\MultipartStream;
+use Psr\Http\Message\StreamInterface;
+
+trait MultipartTrait
+{
+    /**
+     * Create a multipart stream from an array of form fields.
+     *
+     * @param array<string, mixed> $fields Array of field name => value pairs
+     *        Values can be:
+     *        - string: raw content
+     *        - resource: file handle
+     *        - StreamInterface: PSR-7 stream
+     *        - array with 'contents' key and optional 'filename', 'headers' keys
+     * @return array{stream: StreamInterface, boundary: string}
+     */
+    protected function createMultipartStream(array $fields): array
+    {
+        $elements = [];
+        foreach ($fields as $name => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_array($value) && isset($value['contents'])) {
+                $elements[] = array_merge(['name' => $name], $value);
+            } else {
+                $elements[] = [
+                    'name' => $name,
+                    'contents' => $value,
+                ];
+            }
+        }
+
+        $stream = new MultipartStream($elements);
+
+        return [
+            'stream' => $stream,
+            'boundary' => $stream->getBoundary(),
+        ];
+    }
+}

--- a/test/Client/MultipartTraitTest.php
+++ b/test/Client/MultipartTraitTest.php
@@ -3,8 +3,10 @@
 namespace CedricZiel\MattermostPhp\Test\Client;
 
 use CedricZiel\MattermostPhp\Client\MultipartTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(MultipartTrait::class)]
 class MultipartTraitTest extends TestCase
 {
     use MultipartTrait;

--- a/test/Client/MultipartTraitTest.php
+++ b/test/Client/MultipartTraitTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace CedricZiel\MattermostPhp\Test\Client;
+
+use CedricZiel\MattermostPhp\Client\MultipartTrait;
+use PHPUnit\Framework\TestCase;
+
+class MultipartTraitTest extends TestCase
+{
+    use MultipartTrait;
+
+    public function testCreateMultipartStreamWithStringContent(): void
+    {
+        $fields = [
+            'channel_id' => 'test-channel-123',
+            'files' => [
+                'contents' => 'file content here',
+                'filename' => 'test.txt',
+            ],
+        ];
+
+        $result = $this->createMultipartStream($fields);
+
+        $this->assertArrayHasKey('stream', $result);
+        $this->assertArrayHasKey('boundary', $result);
+        $this->assertNotEmpty($result['boundary']);
+
+        $body = (string) $result['stream'];
+        $this->assertStringContainsString('channel_id', $body);
+        $this->assertStringContainsString('test-channel-123', $body);
+        $this->assertStringContainsString('file content here', $body);
+        $this->assertStringContainsString('test.txt', $body);
+    }
+
+    public function testCreateMultipartStreamSkipsNullValues(): void
+    {
+        $fields = [
+            'channel_id' => 'test-channel',
+            'client_ids' => null,
+            'files' => ['contents' => 'content'],
+        ];
+
+        $result = $this->createMultipartStream($fields);
+        $body = (string) $result['stream'];
+
+        $this->assertStringContainsString('channel_id', $body);
+        $this->assertStringNotContainsString('client_ids', $body);
+    }
+
+    public function testCreateMultipartStreamWithSimpleValues(): void
+    {
+        $fields = [
+            'field1' => 'value1',
+            'field2' => 'value2',
+        ];
+
+        $result = $this->createMultipartStream($fields);
+        $body = (string) $result['stream'];
+
+        $this->assertStringContainsString('field1', $body);
+        $this->assertStringContainsString('value1', $body);
+        $this->assertStringContainsString('field2', $body);
+        $this->assertStringContainsString('value2', $body);
+    }
+
+    public function testBoundaryIsUnique(): void
+    {
+        $fields = ['test' => 'value'];
+
+        $result1 = $this->createMultipartStream($fields);
+        $result2 = $this->createMultipartStream($fields);
+
+        $this->assertNotEquals($result1['boundary'], $result2['boundary']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #290 - The `uploadFile` endpoint and other file upload methods were sending empty POST bodies because the code generator only handled `application/json` request bodies.

- Add `MultipartTrait` for creating multipart streams using Guzzle's PSR-7 `MultipartStream`
- Update `bin/api-generate` to detect and handle `multipart/form-data` request bodies
- Regenerate all affected endpoints (11 classes with file upload support)
- Add tests for `MultipartTrait` functionality

### Affected Endpoints

| Endpoint | Methods |
|----------|---------|
| `FilesEndpoint` | `uploadFile()` |
| `UsersEndpoint` | `setProfileImage()` |
| `TeamsEndpoint` | `setTeamIcon()`, `importTeam()` |
| `EmojiEndpoint` | `createEmoji()` |
| `PluginsEndpoint` | `uploadPlugin()` |
| `BotsEndpoint` | `setBotIconImage()` |
| `BrandEndpoint` | `uploadBrandImage()` |
| `SystemEndpoint` | `uploadLicenseFile()` |
| `SAMLEndpoint` | Certificate uploads |
| `LDAPEndpoint` | Certificate uploads |
| `CloudEndpoint` | File uploads |

### New API Usage

```php
$client->files()->uploadFile(
    files: fopen('/path/to/file.pdf', 'r'),  // or string content
    channel_id: 'channel123',
    client_ids: 'optional-client-id',
);
```

## Test plan

- [x] PHPStan static analysis passes
- [x] All existing tests pass
- [x] New `MultipartTraitTest` passes (4 tests, 14 assertions)
- [ ] Manual testing against a Mattermost server (recommended)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File upload support added to multiple endpoints: bot icons, brand images, user avatars, team icons, SAML and LDAP certificates, plugins, and license files
  * Updated API methods to accept file and image parameters with improved form-data handling

* **Tests**
  * Comprehensive test coverage for multipart form-data functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->