### PR TITLE
ci: update to googleapis/release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           release-type: php


### PR DESCRIPTION
## Summary

- Update release-please action reference from `google-github-actions/release-please-action@v4` to `googleapis/release-please-action@v4`

The action was moved to the googleapis organization.