### PR TITLE
docs: add comprehensive documentation and GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/api-client.md
+++ b/docs/api-client.md
@@ -1,0 +1,228 @@
+# API Client
+
+The API client provides a fluent, type-safe interface to the Mattermost REST API. It is auto-generated from the official Mattermost OpenAPI specification.
+
+## Overview
+
+The client organizes API endpoints into logical groups accessible via method calls:
+
+```php
+$client->users()      // User management
+$client->teams()      // Team operations
+$client->channels()   // Channel operations
+$client->posts()      // Post/message operations
+$client->files()      // File uploads/downloads
+// ... and 40+ more endpoint groups
+```
+
+## Available Endpoint Groups
+
+| Method | Description |
+|--------|-------------|
+| `users()` | User management, authentication, preferences |
+| `teams()` | Team creation, membership, settings |
+| `channels()` | Channel management, membership |
+| `posts()` | Create, update, delete messages |
+| `files()` | File upload/download |
+| `reactions()` | Message reactions |
+| `emoji()` | Custom emoji management |
+| `webhooks()` | Incoming/outgoing webhooks |
+| `bots()` | Bot account management |
+| `commands()` | Slash command configuration |
+| `plugins()` | Plugin management |
+| `system()` | System configuration |
+| `jobs()` | Background job management |
+| `compliance()` | Compliance exports |
+| `groups()` | LDAP/AD groups |
+| `roles()` | Role and permission management |
+| `status()` | User presence status |
+| `threads()` | Thread management |
+
+See the `Client` class for the complete list of available endpoints.
+
+## Common Operations
+
+### Working with Users
+
+```php
+// Get current user
+$me = $client->users()->getUser('me');
+
+// Get user by username
+$user = $client->users()->getUserByUsername('john.doe');
+
+// Search users
+$users = $client->users()->searchUsers(
+    new SearchUsersRequest(term: 'john')
+);
+
+// Update user status
+$client->status()->updateUserStatus(
+    $userId,
+    new UpdateUserStatusRequest(status: 'online')
+);
+```
+
+### Working with Teams
+
+```php
+// Get team by name
+$team = $client->teams()->getTeamByName('my-team');
+
+// List teams for user
+$teams = $client->teams()->getTeamsForUser($userId);
+
+// Get team members
+$members = $client->teams()->getTeamMembers($team->id);
+```
+
+### Working with Channels
+
+```php
+// Get channel by name
+$channel = $client->channels()->getChannelByName($teamId, 'general');
+
+// Create a channel
+$newChannel = $client->channels()->createChannel(
+    new CreateChannelRequest(
+        team_id: $teamId,
+        name: 'my-channel',
+        display_name: 'My Channel',
+        type: 'O'  // O = public, P = private
+    )
+);
+
+// List channels
+$channels = $client->channels()->getAllChannels(per_page: 100);
+
+// Add user to channel
+$client->channels()->addChannelMember(
+    $channelId,
+    new AddChannelMemberRequest(user_id: $userId)
+);
+```
+
+### Working with Posts
+
+```php
+use CedricZiel\MattermostPhp\Client\Model\CreatePostRequest;
+
+// Create a post
+$post = $client->posts()->createPost(
+    new CreatePostRequest(
+        channel_id: $channelId,
+        message: 'Hello, world!'
+    )
+);
+
+// Create a post with props
+$post = $client->posts()->createPost(
+    new CreatePostRequest(
+        channel_id: $channelId,
+        message: 'Check this out',
+        props: (object)['key' => 'value']
+    )
+);
+
+// Get posts in channel
+$posts = $client->posts()->getPostsForChannel($channelId);
+
+// Update a post
+$client->posts()->updatePost(
+    $postId,
+    new UpdatePostRequest(message: 'Updated message')
+);
+
+// Delete a post
+$client->posts()->deletePost($postId);
+```
+
+### Working with Files
+
+```php
+// Upload a file
+$fileInfo = $client->files()->uploadFile(
+    channel_id: $channelId,
+    files: file_get_contents('/path/to/file.pdf'),
+    filename: 'document.pdf'
+);
+
+// Create post with attachment
+$post = $client->posts()->createPost(
+    new CreatePostRequest(
+        channel_id: $channelId,
+        message: 'See attached file',
+        file_ids: [$fileInfo->file_infos[0]->id]
+    )
+);
+
+// Get file info
+$info = $client->files()->getFile($fileId);
+
+// Download file
+$content = $client->files()->getFileContent($fileId);
+```
+
+## Error Handling
+
+API calls may throw exceptions on errors:
+
+```php
+use Psr\Http\Client\ClientExceptionInterface;
+
+try {
+    $user = $client->users()->getUser('non-existent-id');
+} catch (ClientExceptionInterface $e) {
+    // Handle HTTP/network errors
+    echo "Request failed: " . $e->getMessage();
+}
+```
+
+The API returns typed response models. Check for error responses:
+
+```php
+$response = $client->users()->getUser($userId);
+
+// Response is a typed model (e.g., User)
+echo $response->username;
+```
+
+## Request Models
+
+Most write operations require request model objects:
+
+```php
+use CedricZiel\MattermostPhp\Client\Model\CreatePostRequest;
+use CedricZiel\MattermostPhp\Client\Model\CreateChannelRequest;
+use CedricZiel\MattermostPhp\Client\Model\UpdateUserRequest;
+
+// Models use named constructor parameters
+$request = new CreatePostRequest(
+    channel_id: $channelId,
+    message: 'Hello!'
+);
+```
+
+## Pagination
+
+Many list endpoints support pagination:
+
+```php
+// Get first page of channels
+$channels = $client->channels()->getAllChannels(
+    page: 0,
+    per_page: 60
+);
+
+// Get next page
+$moreChannels = $client->channels()->getAllChannels(
+    page: 1,
+    per_page: 60
+);
+```
+
+## Next Steps
+
+- [Apps Framework](apps-framework.md) - Build Mattermost Apps
+- [Slash Commands](slash-commands.md) - Create custom slash commands
+- [Examples](examples.md) - More code examples

--- a/docs/apps-framework.md
+++ b/docs/apps-framework.md
@@ -1,0 +1,268 @@
+# Apps Framework
+
+The Apps Framework provides a PSR-15 compatible request handler for building [Mattermost Apps](https://developers.mattermost.com/integrate/apps/). Apps can extend Mattermost with custom commands, channel header buttons, post menu actions, and more.
+
+## Overview
+
+A Mattermost App consists of:
+
+- A **Manifest** that describes the app
+- **Bindings** that define UI integration points
+- **Handlers** that respond to user interactions
+
+## Creating an App
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Apps\MattermostApp;
+use CedricZiel\MattermostPhp\Apps\HttpDeploymentDescriptor;
+
+$app = MattermostApp::create(
+    'my-app',                              // App ID
+    'My Custom App',                       // Display name
+    'https://example.com'                  // Homepage URL
+);
+
+// Configure HTTP deployment
+$app->withHttp(new HttpDeploymentDescriptor(
+    rootUrl: 'https://your-app.example.com'
+));
+```
+
+## Locations and Bindings
+
+Apps can add UI elements to different locations in Mattermost:
+
+| Location | Description |
+|----------|-------------|
+| `/channel_header` | Buttons in the channel header |
+| `/post_menu` | Items in the post context menu |
+| `/command` | Slash commands |
+| `/in_post` | Embedded content in posts |
+
+### Adding Bindings
+
+```php
+use CedricZiel\MattermostPhp\Apps\Location;
+use CedricZiel\MattermostPhp\Apps\Bindings\LocationBinding;
+use CedricZiel\MattermostPhp\Apps\Call;
+
+// Add a channel header button
+$app->addBinding(
+    Location::channel_header,
+    new LocationBinding(
+        location: 'my-button',
+        label: 'My Button',
+        submit: new Call(path: '/my-action')
+    )
+);
+
+// Add a slash command
+$app->addBinding(
+    Location::command,
+    new LocationBinding(
+        location: 'my-command',
+        label: 'My Command',
+        description: 'Does something useful',
+        submit: new Call(path: '/my-command')
+    )
+);
+
+// Add a post menu item
+$app->addBinding(
+    Location::post_menu,
+    new LocationBinding(
+        location: 'my-menu-item',
+        label: 'Process Post',
+        submit: new Call(path: '/process-post')
+    )
+);
+```
+
+## Handling Requests
+
+The `MattermostApp` class implements PSR-15's `RequestHandlerInterface`:
+
+```php
+use Psr\Http\Message\ServerRequestInterface;
+
+// In your application entry point
+$response = $app->handle($serverRequest);
+```
+
+The app automatically handles these endpoints:
+
+| Path | Purpose |
+|------|---------|
+| `/manifest.json` | Returns the app manifest |
+| `/bindings` | Returns UI bindings |
+| `/on-install` | Called when app is installed |
+| `/on-uninstall` | Called when app is uninstalled |
+| `/version-changed` | Called when app version changes |
+
+## Lifecycle Events
+
+Use PSR-14 events to respond to lifecycle hooks:
+
+```php
+use CedricZiel\MattermostPhp\Apps\Events\OnInstallEvent;
+use CedricZiel\MattermostPhp\Apps\Events\OnUninstallEvent;
+use CedricZiel\MattermostPhp\Apps\Events\OnBindingsRequestEvent;
+
+// With a PSR-14 event dispatcher
+$app->withEventDispatcher($eventDispatcher);
+
+// Then in your event subscriber
+class AppEventSubscriber
+{
+    public function onInstall(OnInstallEvent $event): void
+    {
+        // Handle installation
+        // e.g., store app credentials, initialize database
+    }
+
+    public function onUninstall(OnUninstallEvent $event): void
+    {
+        // Handle uninstallation
+        // e.g., cleanup resources
+    }
+}
+```
+
+Available events:
+
+- `OnInstallEvent` - App was installed
+- `OnUninstallEvent` - App was uninstalled
+- `OnVersionChangedEvent` - App version was updated
+- `OnBindingsRequestEvent` - Bindings were requested
+- `OnManifestRequestEvent` - Manifest was requested
+
+## Permissions
+
+Request permissions your app needs:
+
+```php
+use CedricZiel\MattermostPhp\Apps\AppPermission;
+
+$app->requestPermission(AppPermission::act_as_bot);
+$app->requestPermission(AppPermission::act_as_user);
+```
+
+## Calls and Responses
+
+When a user interacts with your app, Mattermost sends a `Call` to your endpoint. Respond with appropriate response types:
+
+```php
+use CedricZiel\MattermostPhp\Apps\Response\OkResponse;
+use CedricZiel\MattermostPhp\Apps\Response\FormResponse;
+use CedricZiel\MattermostPhp\Apps\Response\NavigateResponse;
+use CedricZiel\MattermostPhp\Apps\Response\ErrorResponse;
+
+// Simple acknowledgment
+$response = new OkResponse();
+
+// Return a form for user input
+$response = new FormResponse($form);
+
+// Navigate user to a URL
+$response = new NavigateResponse('https://example.com');
+
+// Return an error
+$response = new ErrorResponse('Something went wrong');
+```
+
+## Forms
+
+Create interactive forms for user input:
+
+```php
+use CedricZiel\MattermostPhp\Apps\Forms\Form;
+use CedricZiel\MattermostPhp\Apps\Forms\Field;
+use CedricZiel\MattermostPhp\Apps\Forms\FieldType;
+
+$form = new Form(
+    title: 'Create Task',
+    submit: new Call(path: '/create-task'),
+    fields: [
+        new Field(
+            name: 'title',
+            type: FieldType::text,
+            label: 'Task Title',
+            is_required: true
+        ),
+        new Field(
+            name: 'description',
+            type: FieldType::text,
+            label: 'Description',
+            subtype: TextFieldSubtype::textarea
+        ),
+        new Field(
+            name: 'priority',
+            type: FieldType::static_select,
+            label: 'Priority',
+            options: [
+                new SelectOption(label: 'High', value: 'high'),
+                new SelectOption(label: 'Medium', value: 'medium'),
+                new SelectOption(label: 'Low', value: 'low'),
+            ]
+        ),
+    ]
+);
+```
+
+## Complete Example
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Apps\MattermostApp;
+use CedricZiel\MattermostPhp\Apps\HttpDeploymentDescriptor;
+use CedricZiel\MattermostPhp\Apps\Location;
+use CedricZiel\MattermostPhp\Apps\Bindings\LocationBinding;
+use CedricZiel\MattermostPhp\Apps\Call;
+use CedricZiel\MattermostPhp\Apps\AppPermission;
+
+$app = MattermostApp::create(
+    'task-manager',
+    'Task Manager',
+    'https://example.com/task-manager'
+);
+
+$app->withHttp(new HttpDeploymentDescriptor(
+    rootUrl: 'https://your-app.example.com/mattermost'
+));
+
+// Request permissions
+$app->requestPermission(AppPermission::act_as_bot);
+
+// Add a slash command
+$app->addBinding(
+    Location::command,
+    new LocationBinding(
+        location: 'task',
+        label: 'task',
+        description: 'Manage tasks',
+        submit: new Call(path: '/task')
+    )
+);
+
+// Add channel header button
+$app->addBinding(
+    Location::channel_header,
+    new LocationBinding(
+        location: 'new-task',
+        label: 'New Task',
+        submit: new Call(path: '/new-task-form')
+    )
+);
+
+// Handle requests (in your PSR-15 application)
+$response = $app->handle($serverRequest);
+```
+
+## Next Steps
+
+- [Slash Commands](slash-commands.md) - Simpler slash command integration
+- [Examples](examples.md) - More code examples
+- [Mattermost Apps Documentation](https://developers.mattermost.com/integrate/apps/)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,484 @@
+# Examples
+
+This page contains practical code examples for common use cases.
+
+## API Client Examples
+
+### Post a Message
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\CreatePostRequest;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+$post = $client->posts()->createPost(
+    new CreatePostRequest(
+        channel_id: 'channel-id-here',
+        message: 'Hello from PHP!'
+    )
+);
+
+echo "Posted message with ID: " . $post->id;
+```
+
+### Post with Attachment
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\CreatePostRequest;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+// Upload file first
+$upload = $client->files()->uploadFile(
+    channel_id: $channelId,
+    files: file_get_contents('/path/to/document.pdf'),
+    filename: 'document.pdf'
+);
+
+// Create post with file attachment
+$post = $client->posts()->createPost(
+    new CreatePostRequest(
+        channel_id: $channelId,
+        message: 'Check out this document',
+        file_ids: [$upload->file_infos[0]->id]
+    )
+);
+```
+
+### Get All Channels for a Team
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+$team = $client->teams()->getTeamByName('my-team');
+
+$page = 0;
+$perPage = 100;
+$allChannels = [];
+
+do {
+    $channels = $client->channels()->getPublicChannelsForTeam(
+        $team->id,
+        page: $page,
+        per_page: $perPage
+    );
+
+    $allChannels = array_merge($allChannels, $channels);
+    $page++;
+} while (count($channels) === $perPage);
+
+echo "Found " . count($allChannels) . " channels\n";
+
+foreach ($allChannels as $channel) {
+    echo "- {$channel->display_name} ({$channel->name})\n";
+}
+```
+
+### Search for Users
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\SearchUsersRequest;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+$users = $client->users()->searchUsers(
+    new SearchUsersRequest(
+        term: 'john',
+        team_id: $teamId
+    )
+);
+
+foreach ($users as $user) {
+    echo "{$user->username} - {$user->email}\n";
+}
+```
+
+### Create a Channel
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\CreateChannelRequest;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+$channel = $client->channels()->createChannel(
+    new CreateChannelRequest(
+        team_id: $teamId,
+        name: 'project-alpha',
+        display_name: 'Project Alpha',
+        purpose: 'Discussions about Project Alpha',
+        header: 'Welcome to Project Alpha!',
+        type: 'O'  // 'O' = public, 'P' = private
+    )
+);
+
+echo "Created channel: " . $channel->display_name;
+```
+
+### Add User to Channel
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\AddChannelMemberRequest;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+$member = $client->channels()->addChannelMember(
+    $channelId,
+    new AddChannelMemberRequest(user_id: $userId)
+);
+
+echo "Added user to channel";
+```
+
+### Set User Status
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\UpdateUserStatusRequest;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+// Get current user
+$me = $client->users()->getUser('me');
+
+// Set status to away
+$client->status()->updateUserStatus(
+    $me->id,
+    new UpdateUserStatusRequest(
+        user_id: $me->id,
+        status: 'away'
+    )
+);
+
+// Available statuses: 'online', 'away', 'offline', 'dnd'
+```
+
+## Slash Command Examples
+
+### Echo Command
+
+A simple command that echoes back the input:
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\SlashCommands\AbstractSlashCommand;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandInput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandOutput;
+
+class EchoCommand extends AbstractSlashCommand
+{
+    public function execute(SlashCommandInput $input): SlashCommandOutput
+    {
+        return SlashCommandOutput::create()
+            ->withText("You said: " . $input->getText());
+    }
+}
+
+// Usage: /echo Hello, world!
+// Response: You said: Hello, world!
+```
+
+### Poll Command
+
+Create a simple poll:
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\SlashCommands\AbstractSlashCommand;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandInput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandOutput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandResponseType;
+
+class PollCommand extends AbstractSlashCommand
+{
+    public function execute(SlashCommandInput $input): SlashCommandOutput
+    {
+        // Parse: /poll "Question" "Option 1" "Option 2" "Option 3"
+        preg_match_all('/"([^"]+)"/', $input->getText(), $matches);
+        $parts = $matches[1] ?? [];
+
+        if (count($parts) < 3) {
+            return SlashCommandOutput::create()
+                ->withText('Usage: /poll "Question" "Option 1" "Option 2" ...');
+        }
+
+        $question = array_shift($parts);
+        $emojis = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
+
+        $text = "**Poll: {$question}**\n\n";
+        foreach ($parts as $i => $option) {
+            $text .= ":{$emojis[$i]}: {$option}\n";
+        }
+        $text .= "\n_React with the corresponding emoji to vote!_";
+
+        return SlashCommandOutput::create()
+            ->withText($text)
+            ->setResponseType(SlashCommandResponseType::IN_CHANNEL);
+    }
+}
+```
+
+### Giphy Command
+
+Fetch a random GIF:
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\SlashCommands\AbstractSlashCommand;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandInput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandOutput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandResponseType;
+
+class GiphyCommand extends AbstractSlashCommand
+{
+    private string $apiKey;
+
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    public function execute(SlashCommandInput $input): SlashCommandOutput
+    {
+        $query = urlencode($input->getText());
+        $url = "https://api.giphy.com/v1/gifs/random?api_key={$this->apiKey}&tag={$query}";
+
+        $response = json_decode(file_get_contents($url), true);
+        $gifUrl = $response['data']['images']['original']['url'] ?? null;
+
+        if (!$gifUrl) {
+            return SlashCommandOutput::create()
+                ->withText("No GIF found for: " . $input->getText());
+        }
+
+        return SlashCommandOutput::create()
+            ->withText("![{$input->getText()}]({$gifUrl})")
+            ->setResponseType(SlashCommandResponseType::IN_CHANNEL);
+    }
+}
+```
+
+## Apps Framework Examples
+
+### Minimal App
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Apps\MattermostApp;
+use CedricZiel\MattermostPhp\Apps\HttpDeploymentDescriptor;
+use CedricZiel\MattermostPhp\Apps\Location;
+use CedricZiel\MattermostPhp\Apps\Bindings\LocationBinding;
+use CedricZiel\MattermostPhp\Apps\Call;
+
+$app = MattermostApp::create(
+    'hello-app',
+    'Hello App',
+    'https://example.com'
+);
+
+$app->withHttp(new HttpDeploymentDescriptor(
+    rootUrl: 'https://your-server.com/mattermost-app'
+));
+
+$app->addBinding(
+    Location::command,
+    new LocationBinding(
+        location: 'hello',
+        label: 'hello',
+        description: 'Say hello',
+        submit: new Call(path: '/hello')
+    )
+);
+
+// Handle the request
+$response = $app->handle($serverRequest);
+```
+
+### App with Form
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Apps\MattermostApp;
+use CedricZiel\MattermostPhp\Apps\HttpDeploymentDescriptor;
+use CedricZiel\MattermostPhp\Apps\Location;
+use CedricZiel\MattermostPhp\Apps\Bindings\LocationBinding;
+use CedricZiel\MattermostPhp\Apps\Call;
+use CedricZiel\MattermostPhp\Apps\Forms\Form;
+use CedricZiel\MattermostPhp\Apps\Forms\Field;
+use CedricZiel\MattermostPhp\Apps\Forms\FieldType;
+
+$app = MattermostApp::create(
+    'feedback-app',
+    'Feedback App',
+    'https://example.com'
+);
+
+$app->withHttp(new HttpDeploymentDescriptor(
+    rootUrl: 'https://your-server.com/feedback'
+));
+
+// Add channel header button that opens a form
+$app->addBinding(
+    Location::channel_header,
+    new LocationBinding(
+        location: 'give-feedback',
+        label: 'Give Feedback',
+        submit: new Call(path: '/feedback-form')
+    )
+);
+
+// In your /feedback-form handler, return:
+$form = new Form(
+    title: 'Submit Feedback',
+    submit: new Call(path: '/submit-feedback'),
+    fields: [
+        new Field(
+            name: 'category',
+            type: FieldType::static_select,
+            label: 'Category',
+            options: [
+                new SelectOption(label: 'Bug Report', value: 'bug'),
+                new SelectOption(label: 'Feature Request', value: 'feature'),
+                new SelectOption(label: 'General Feedback', value: 'general'),
+            ]
+        ),
+        new Field(
+            name: 'message',
+            type: FieldType::text,
+            label: 'Your Feedback',
+            is_required: true
+        ),
+    ]
+);
+```
+
+## Integration with Frameworks
+
+### Slim Framework
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\SlashCommands\AbstractSlashCommand;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandInput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandOutput;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+require __DIR__ . '/vendor/autoload.php';
+
+class MyCommand extends AbstractSlashCommand
+{
+    public function execute(SlashCommandInput $input): SlashCommandOutput
+    {
+        return SlashCommandOutput::create()
+            ->withText('Hello from Slim!');
+    }
+}
+
+$app = AppFactory::create();
+
+$app->post('/slash/mycommand', function (Request $request, Response $response) {
+    $command = new MyCommand();
+    return $command->handle($request);
+});
+
+$app->run();
+```
+
+### Laravel
+
+```php
+<?php
+
+// app/Http/Controllers/SlashCommandController.php
+
+namespace App\Http\Controllers;
+
+use CedricZiel\MattermostPhp\SlashCommands\AbstractSlashCommand;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandInput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandOutput;
+use Illuminate\Http\Request;
+
+class MyCommand extends AbstractSlashCommand
+{
+    public function execute(SlashCommandInput $input): SlashCommandOutput
+    {
+        return SlashCommandOutput::create()
+            ->withText('Hello from Laravel!');
+    }
+}
+
+class SlashCommandController extends Controller
+{
+    public function handle(Request $request)
+    {
+        $command = new MyCommand();
+        $psrRequest = /* convert Laravel request to PSR-7 */;
+
+        return $command->handle($psrRequest);
+    }
+}
+```
+
+## Error Handling
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use Psr\Http\Client\ClientExceptionInterface;
+
+$client = new Client('https://mattermost.example.com');
+$client->setToken('your-token');
+
+try {
+    $user = $client->users()->getUser('non-existent-id');
+} catch (ClientExceptionInterface $e) {
+    error_log("Mattermost API error: " . $e->getMessage());
+
+    // Handle gracefully
+    echo "Unable to fetch user. Please try again later.";
+}
+```
+
+## More Resources
+
+- [Getting Started](getting-started.md)
+- [API Client Guide](api-client.md)
+- [Apps Framework](apps-framework.md)
+- [Slash Commands](slash-commands.md)
+- [Mattermost Developer Docs](https://developers.mattermost.com/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,7 @@ echo "Authenticated as: " . $user->username;
 ```
 
 To create a personal access token in Mattermost:
+
 1. Go to **Settings > Security > Personal Access Tokens**
 2. Click **Create Token**
 3. Copy the token (it won't be shown again)
@@ -90,6 +91,7 @@ echo "Created post with ID: " . $post->id;
 The SDK uses [PSR-18](https://www.php-fig.org/psr/psr-18/) HTTP client discovery. It will automatically find and use any installed PSR-18 compatible HTTP client.
 
 Popular options include:
+
 - `guzzlehttp/guzzle`
 - `symfony/http-client`
 - `php-http/curl-client`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,115 @@
+# Getting Started
+
+This guide will help you install and configure the Mattermost PHP SDK.
+
+## Requirements
+
+- PHP 8.2 or higher
+- Composer
+- A Mattermost instance with API access
+
+## Installation
+
+Install the SDK via Composer:
+
+```bash
+composer require cedricziel/mattermost-php
+```
+
+## Creating a Client
+
+The `Client` class is the main entry point for interacting with the Mattermost API.
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+
+$client = new Client('https://your-mattermost-instance.com');
+```
+
+## Authentication
+
+### Token Authentication (Recommended)
+
+Use a personal access token or bot token:
+
+```php
+$client->setToken('your-access-token');
+
+// Verify the token works
+$user = $client->authenticate();
+echo "Authenticated as: " . $user->username;
+```
+
+To create a personal access token in Mattermost:
+1. Go to **Settings > Security > Personal Access Tokens**
+2. Click **Create Token**
+3. Copy the token (it won't be shown again)
+
+### Username/Password Authentication
+
+Alternatively, authenticate with credentials:
+
+```php
+$user = $client->authenticate('username', 'password');
+```
+
+This will obtain a session token internally.
+
+## Your First API Call
+
+Here's a complete example that posts a message to a channel:
+
+```php
+<?php
+
+require_once 'vendor/autoload.php';
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\CreatePostRequest;
+
+// Create and authenticate the client
+$client = new Client('https://your-mattermost-instance.com');
+$client->setToken('your-access-token');
+
+// Get team and channel
+$team = $client->teams()->getTeamByName('my-team');
+$channel = $client->channels()->getChannelByName($team->id, 'town-square');
+
+// Create a post
+$post = $client->posts()->createPost(
+    new CreatePostRequest($channel->id, 'Hello from the PHP SDK!')
+);
+
+echo "Created post with ID: " . $post->id;
+```
+
+## PSR-18 HTTP Client
+
+The SDK uses [PSR-18](https://www.php-fig.org/psr/psr-18/) HTTP client discovery. It will automatically find and use any installed PSR-18 compatible HTTP client.
+
+Popular options include:
+- `guzzlehttp/guzzle`
+- `symfony/http-client`
+- `php-http/curl-client`
+
+You can also provide your own HTTP client:
+
+```php
+use CedricZiel\MattermostPhp\Client;
+
+$client = new Client(
+    baseUrl: 'https://your-mattermost-instance.com',
+    httpClient: $yourPsr18Client,
+    requestFactory: $yourPsr17RequestFactory,
+    streamFactory: $yourPsr17StreamFactory,
+);
+```
+
+## Next Steps
+
+- [API Client Guide](api-client.md) - Learn about all available endpoints
+- [Apps Framework](apps-framework.md) - Build Mattermost Apps
+- [Slash Commands](slash-commands.md) - Create custom slash commands
+- [Examples](examples.md) - More code examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,55 @@
+# Mattermost PHP SDK
+
+A PHP SDK for building apps and integrations for Mattermost.
+
+## Features
+
+- **API Client** - Fluent, type-safe wrapper around the Mattermost REST API with 40+ endpoint groups
+- **Apps Framework** - PSR-15 request handler for building [Mattermost Apps](https://developers.mattermost.com/integrate/apps/)
+- **Slash Commands** - Framework for implementing custom slash commands
+
+## Quick Links
+
+- [Getting Started](getting-started.md) - Installation and first steps
+- [API Client](api-client.md) - Using the REST API client
+- [Apps Framework](apps-framework.md) - Building Mattermost Apps
+- [Slash Commands](slash-commands.md) - Custom slash command development
+- [Examples](examples.md) - Code examples for common use cases
+
+## Requirements
+
+- PHP 8.2 or higher
+- Composer
+
+## Installation
+
+```bash
+composer require cedricziel/mattermost-php
+```
+
+## Quick Example
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\Client;
+use CedricZiel\MattermostPhp\Client\Model\CreatePostRequest;
+
+$client = new Client('https://your-mattermost-instance.com');
+$client->setToken('your-access-token');
+
+// Get a channel and post a message
+$team = $client->teams()->getTeamByName('my-team');
+$channel = $client->channels()->getChannelByName($team->id, 'town-square');
+$post = $client->posts()->createPost(new CreatePostRequest($channel->id, 'Hello from PHP!'));
+```
+
+## Links
+
+- [GitHub Repository](https://github.com/cedricziel/mattermost-php)
+- [Packagist](https://packagist.org/packages/cedricziel/mattermost-php)
+- [Mattermost Developer Documentation](https://developers.mattermost.com/)
+
+## License
+
+MIT

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,0 +1,311 @@
+# Slash Commands
+
+Slash commands are one of the most common ways to integrate with Mattermost. Users invoke them by typing a slash followed by the command name (e.g., `/weather toronto`).
+
+This library provides an `AbstractSlashCommand` class for implementing custom slash commands with PSR-15 compatible request handling.
+
+## Overview
+
+To create a slash command:
+
+1. Extend `AbstractSlashCommand`
+2. Implement the `execute()` method
+3. Return a `SlashCommandOutput`
+
+## Basic Example
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\SlashCommands\AbstractSlashCommand;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandInput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandOutput;
+
+class WeatherCommand extends AbstractSlashCommand
+{
+    public function execute(SlashCommandInput $input): SlashCommandOutput
+    {
+        $city = $input->getText();
+
+        // Your business logic here
+        $weather = $this->getWeatherForCity($city);
+
+        return SlashCommandOutput::create()
+            ->withText("The weather in {$city} is {$weather}");
+    }
+
+    private function getWeatherForCity(string $city): string
+    {
+        // Fetch weather data from an API
+        return 'sunny, 22°C';
+    }
+}
+```
+
+## Handling Requests
+
+The `AbstractSlashCommand` implements PSR-15's `RequestHandlerInterface`:
+
+```php
+// In your application entry point
+$command = new WeatherCommand();
+$response = $command->handle($serverRequest);
+
+// $response is a PSR-7 ResponseInterface
+```
+
+## SlashCommandInput
+
+The `SlashCommandInput` class provides access to all data sent by Mattermost:
+
+```php
+public function execute(SlashCommandInput $input): SlashCommandOutput
+{
+    // Command text (everything after the command name)
+    $text = $input->getText();           // e.g., "toronto week"
+
+    // The command that was invoked
+    $command = $input->getCommand();     // e.g., "/weather"
+
+    // Channel where command was invoked
+    $channelId = $input->getChannelId();
+    $channelName = $input->getChannelName();
+
+    // Team information
+    $teamId = $input->getTeamId();
+    $teamDomain = $input->getTeamDomain();
+
+    // User who invoked the command
+    $userId = $input->getUserId();
+    $userName = $input->getUserName();
+
+    // For delayed responses
+    $responseUrl = $input->getResponseUrl();
+
+    // Verification token
+    $token = $input->getToken();
+
+    // For interactive components
+    $triggerId = $input->getTriggerId();
+
+    // Additional context (if any)
+    $context = $input->getContext();
+
+    // Access the original PSR-7 request
+    $request = $input->getRequest();
+
+    // ...
+}
+```
+
+## SlashCommandOutput
+
+The `SlashCommandOutput` class provides a fluent interface for building responses:
+
+### Basic Text Response
+
+```php
+return SlashCommandOutput::create()
+    ->withText('Hello, world!');
+```
+
+### Response Types
+
+```php
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandResponseType;
+
+// Ephemeral (only visible to the user who invoked the command)
+return SlashCommandOutput::create()
+    ->withText('Only you can see this')
+    ->setResponseType(SlashCommandResponseType::EPHEMERAL);
+
+// In-channel (visible to everyone in the channel)
+return SlashCommandOutput::create()
+    ->withText('Everyone can see this')
+    ->setResponseType(SlashCommandResponseType::IN_CHANNEL);
+```
+
+### Rich Responses with Attachments
+
+```php
+use CedricZiel\MattermostPhp\Common\Attachments\Attachment;
+use CedricZiel\MattermostPhp\Common\Attachments\Field;
+
+return SlashCommandOutput::create()
+    ->withText('Weather Report')
+    ->addAttachment(
+        (new Attachment())
+            ->setTitle('Toronto Weather')
+            ->setColor('#00FF00')
+            ->addField(new Field('Temperature', '22°C', true))
+            ->addField(new Field('Condition', 'Sunny', true))
+            ->addField(new Field('Humidity', '45%', true))
+    );
+```
+
+### Custom Username and Icon
+
+```php
+return SlashCommandOutput::create()
+    ->withText('Automated message')
+    ->setUsername('Weather Bot')
+    ->setIconUrl('https://example.com/weather-icon.png');
+```
+
+### Navigate to URL
+
+```php
+return SlashCommandOutput::create()
+    ->setGotoLocation('https://example.com/detailed-report');
+```
+
+### Post to Different Channel
+
+```php
+return SlashCommandOutput::create()
+    ->withText('Cross-posted message')
+    ->setChannelId($differentChannelId);
+```
+
+### Extra Responses
+
+Send multiple messages:
+
+```php
+$extra = SlashCommandOutput::create()
+    ->withText('This is a follow-up message');
+
+return SlashCommandOutput::create()
+    ->withText('Main message')
+    ->addExtraResponse($extra);
+```
+
+### Skip Slack Parsing
+
+Disable Slack-compatible markdown parsing:
+
+```php
+return SlashCommandOutput::create()
+    ->withText('Raw text: *not bold*')
+    ->skipSlackParsing();
+```
+
+### Custom Props
+
+Add custom properties to the response:
+
+```php
+return SlashCommandOutput::create()
+    ->withText('Message with props')
+    ->addProp('custom_key', 'custom_value');
+```
+
+## Complete Example
+
+```php
+<?php
+
+use CedricZiel\MattermostPhp\SlashCommands\AbstractSlashCommand;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandInput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandOutput;
+use CedricZiel\MattermostPhp\SlashCommands\SlashCommandResponseType;
+use CedricZiel\MattermostPhp\Common\Attachments\Attachment;
+use CedricZiel\MattermostPhp\Common\Attachments\Field;
+
+class TaskCommand extends AbstractSlashCommand
+{
+    public function execute(SlashCommandInput $input): SlashCommandOutput
+    {
+        $args = explode(' ', $input->getText(), 2);
+        $action = $args[0] ?? 'list';
+        $param = $args[1] ?? '';
+
+        return match($action) {
+            'add' => $this->addTask($param, $input),
+            'list' => $this->listTasks($input),
+            'done' => $this->completeTask($param, $input),
+            default => $this->showHelp(),
+        };
+    }
+
+    private function addTask(string $title, SlashCommandInput $input): SlashCommandOutput
+    {
+        // Add task to your system...
+
+        return SlashCommandOutput::create()
+            ->withText("Task added: {$title}")
+            ->setResponseType(SlashCommandResponseType::EPHEMERAL);
+    }
+
+    private function listTasks(SlashCommandInput $input): SlashCommandOutput
+    {
+        // Get tasks from your system...
+        $tasks = ['Task 1', 'Task 2', 'Task 3'];
+
+        $attachment = (new Attachment())
+            ->setTitle('Your Tasks')
+            ->setColor('#0066FF');
+
+        foreach ($tasks as $i => $task) {
+            $attachment->addField(new Field((string)($i + 1), $task, false));
+        }
+
+        return SlashCommandOutput::create()
+            ->addAttachment($attachment);
+    }
+
+    private function completeTask(string $id, SlashCommandInput $input): SlashCommandOutput
+    {
+        // Mark task complete...
+
+        return SlashCommandOutput::create()
+            ->withText("Task {$id} marked complete!")
+            ->setResponseType(SlashCommandResponseType::IN_CHANNEL);
+    }
+
+    private function showHelp(): SlashCommandOutput
+    {
+        return SlashCommandOutput::create()
+            ->withText(<<<HELP
+            **Task Command Help**
+            - `/task add <title>` - Add a new task
+            - `/task list` - List your tasks
+            - `/task done <id>` - Mark a task complete
+            HELP);
+    }
+}
+```
+
+## Setting Up in Mattermost
+
+1. Go to **Main Menu > Integrations > Slash Commands**
+2. Click **Add Slash Command**
+3. Configure:
+   - **Title**: Your command name
+   - **Command Trigger Word**: The word after `/` (e.g., `task`)
+   - **Request URL**: Your endpoint URL
+   - **Request Method**: POST
+4. Save and note the **Token** for verification
+
+## Token Verification
+
+Verify the token to ensure requests are from your Mattermost instance:
+
+```php
+public function execute(SlashCommandInput $input): SlashCommandOutput
+{
+    if ($input->getToken() !== $_ENV['MATTERMOST_SLASH_TOKEN']) {
+        return SlashCommandOutput::create()
+            ->withText('Unauthorized')
+            ->setResponseType(SlashCommandResponseType::EPHEMERAL);
+    }
+
+    // Process command...
+}
+```
+
+## Next Steps
+
+- [Apps Framework](apps-framework.md) - For more complex integrations
+- [Examples](examples.md) - More code examples
+- [Mattermost Slash Commands Docs](https://developers.mattermost.com/integrate/slash-commands/)


### PR DESCRIPTION
## Summary

- Add curated markdown documentation for the library
- Add GitHub Actions workflow to deploy docs to GitHub Pages

## Documentation Structure

- `docs/index.md` - Landing page with overview and quick links
- `docs/getting-started.md` - Installation, authentication, first API call
- `docs/api-client.md` - API client usage with endpoint reference
- `docs/apps-framework.md` - Guide for building Mattermost Apps
- `docs/slash-commands.md` - Slash command development guide
- `docs/examples.md` - Practical code examples

## GitHub Pages Deployment

The workflow (`.github/workflows/docs.yml`) will automatically deploy the `docs/` directory to GitHub Pages when changes are pushed to `main`.

**Note:** After merging, enable GitHub Pages in repository Settings > Pages with Source set to "GitHub Actions".

## Test plan

- [ ] Review documentation content for accuracy
- [ ] Merge and verify GitHub Pages deployment
- [ ] Enable GitHub Pages in repository settings

Closes #289