### PR TITLE
fix(docs): add Jekyll config for GitHub Pages HTML rendering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,8 @@ name: Documentation
 
 on:
   push:
-    branches: [main]
+    paths: ['docs/**']
+  pull_request:
     paths: ['docs/**']
   workflow_dispatch:
 
@@ -12,8 +13,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -24,12 +25,19 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs
+          path: ./_site
 
   deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,5 @@
+title: Mattermost PHP SDK
+description: A PHP SDK for building apps and integrations for Mattermost
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-remote-theme

--- a/docs/api-client.md
+++ b/docs/api-client.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: API Client
+---
+
 # API Client
 
 The API client provides a fluent, type-safe interface to the Mattermost REST API. It is auto-generated from the official Mattermost OpenAPI specification.
@@ -223,6 +228,6 @@ $moreChannels = $client->channels()->getAllChannels(
 
 ## Next Steps
 
-- [Apps Framework](apps-framework.md) - Build Mattermost Apps
-- [Slash Commands](slash-commands.md) - Create custom slash commands
-- [Examples](examples.md) - More code examples
+- [Apps Framework](apps-framework) - Build Mattermost Apps
+- [Slash Commands](slash-commands) - Create custom slash commands
+- [Examples](examples) - More code examples

--- a/docs/apps-framework.md
+++ b/docs/apps-framework.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Apps Framework
+---
+
 # Apps Framework
 
 The Apps Framework provides a PSR-15 compatible request handler for building [Mattermost Apps](https://developers.mattermost.com/integrate/apps/). Apps can extend Mattermost with custom commands, channel header buttons, post menu actions, and more.
@@ -263,6 +268,6 @@ $response = $app->handle($serverRequest);
 
 ## Next Steps
 
-- [Slash Commands](slash-commands.md) - Simpler slash command integration
-- [Examples](examples.md) - More code examples
+- [Slash Commands](slash-commands) - Simpler slash command integration
+- [Examples](examples) - More code examples
 - [Mattermost Apps Documentation](https://developers.mattermost.com/integrate/apps/)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Examples
+---
+
 # Examples
 
 This page contains practical code examples for common use cases.
@@ -477,8 +482,8 @@ try {
 
 ## More Resources
 
-- [Getting Started](getting-started.md)
-- [API Client Guide](api-client.md)
-- [Apps Framework](apps-framework.md)
-- [Slash Commands](slash-commands.md)
+- [Getting Started](getting-started)
+- [API Client Guide](api-client)
+- [Apps Framework](apps-framework)
+- [Slash Commands](slash-commands)
 - [Mattermost Developer Docs](https://developers.mattermost.com/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Getting Started
+---
+
 # Getting Started
 
 This guide will help you install and configure the Mattermost PHP SDK.
@@ -111,7 +116,7 @@ $client = new Client(
 
 ## Next Steps
 
-- [API Client Guide](api-client.md) - Learn about all available endpoints
-- [Apps Framework](apps-framework.md) - Build Mattermost Apps
-- [Slash Commands](slash-commands.md) - Create custom slash commands
-- [Examples](examples.md) - More code examples
+- [API Client Guide](api-client) - Learn about all available endpoints
+- [Apps Framework](apps-framework) - Build Mattermost Apps
+- [Slash Commands](slash-commands) - Create custom slash commands
+- [Examples](examples) - More code examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Home
+---
+
 # Mattermost PHP SDK
 
 A PHP SDK for building apps and integrations for Mattermost.
@@ -10,11 +15,11 @@ A PHP SDK for building apps and integrations for Mattermost.
 
 ## Quick Links
 
-- [Getting Started](getting-started.md) - Installation and first steps
-- [API Client](api-client.md) - Using the REST API client
-- [Apps Framework](apps-framework.md) - Building Mattermost Apps
-- [Slash Commands](slash-commands.md) - Custom slash command development
-- [Examples](examples.md) - Code examples for common use cases
+- [Getting Started](getting-started) - Installation and first steps
+- [API Client](api-client) - Using the REST API client
+- [Apps Framework](apps-framework) - Building Mattermost Apps
+- [Slash Commands](slash-commands) - Custom slash command development
+- [Examples](examples) - Code examples for common use cases
 
 ## Requirements
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Slash Commands
+---
+
 # Slash Commands
 
 Slash commands are one of the most common ways to integrate with Mattermost. Users invoke them by typing a slash followed by the command name (e.g., `/weather toronto`).
@@ -306,6 +311,6 @@ public function execute(SlashCommandInput $input): SlashCommandOutput
 
 ## Next Steps
 
-- [Apps Framework](apps-framework.md) - For more complex integrations
-- [Examples](examples.md) - More code examples
+- [Apps Framework](apps-framework) - For more complex integrations
+- [Examples](examples) - More code examples
 - [Mattermost Slash Commands Docs](https://developers.mattermost.com/integrate/slash-commands/)


### PR DESCRIPTION
## Summary

Fixes the documentation to properly render as HTML on GitHub Pages.

## Changes

- Add `_config.yml` with Cayman theme for Jekyll
- Add YAML front matter to all markdown files (required for Jekyll processing)
- Fix internal links to work without `.md` extension

## Test plan

- [ ] Merge and verify docs render correctly at https://cedricziel.github.io/mattermost-php/