### PR TITLE
Refactor uploadFile

### DIFF
--- a/src/Client/Endpoint/FilesEndpoint.php
+++ b/src/Client/Endpoint/FilesEndpoint.php
@@ -56,7 +56,7 @@ class FilesEndpoint
         /** A file to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
         mixed $files,
         /** The ID of the channel that this file will be uploaded to */
-        string $channel_id,
+        ?string $channel_id = null,
         /** A unique identifier for the file that will be returned in the response */
         ?string $client_ids = null,
     ): \CedricZiel\MattermostPhp\Client\Model\UploadFileResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse|\CedricZiel\MattermostPhp\Client\Response\BinaryResponse {
@@ -75,7 +75,7 @@ class FilesEndpoint
         // Build multipart form data
         $multipartFields = [];
         if ($files !== null) {
-            $file_name = pathinfo($files, PATHINFO_FILENAME);
+            $file_name = pathinfo($filename, PATHINFO_FILENAME);
             $multipartFields['files'] = ['contents' => $files, 'name' => $file_name, 'filename' => $filename];
         }
         if ($channel_id !== null) {

--- a/src/Client/Endpoint/FilesEndpoint.php
+++ b/src/Client/Endpoint/FilesEndpoint.php
@@ -51,14 +51,14 @@ class FilesEndpoint
      * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function uploadFile(
+        /** The name of the file to be uploaded */
+        string $filename,
         /** A file to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
         mixed $files = null,
         /** The ID of the channel that this file will be uploaded to */
-        ?string $channel_id = null,
+        string $channel_id,
         /** A unique identifier for the file that will be returned in the response */
         ?string $client_ids = null,
-        /** The name of the file to be uploaded */
-        ?string $filename = null,
     ): \CedricZiel\MattermostPhp\Client\Model\UploadFileResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultBadRequestResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultUnauthorizedResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultForbiddenResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultTooLargeResponse|\CedricZiel\MattermostPhp\Client\Model\DefaultNotImplementedResponse|\CedricZiel\MattermostPhp\Client\Response\BinaryResponse {
         $pathParameters = [];
         $queryParameters = [];
@@ -75,7 +75,8 @@ class FilesEndpoint
         // Build multipart form data
         $multipartFields = [];
         if ($files !== null) {
-            $multipartFields['files'] = ['contents' => $files, 'filename' => 'files'];
+            $file_name = pathinfo($files, PATHINFO_FILENAME);
+            $multipartFields['files'] = ['contents' => $files, 'name' => $file_name, 'filename' => $filename];
         }
         if ($channel_id !== null) {
             $multipartFields['channel_id'] = $channel_id;

--- a/src/Client/Endpoint/FilesEndpoint.php
+++ b/src/Client/Endpoint/FilesEndpoint.php
@@ -54,7 +54,7 @@ class FilesEndpoint
         /** The name of the file to be uploaded */
         string $filename,
         /** A file to be uploaded (string|resource|\Psr\Http\Message\StreamInterface) */
-        mixed $files = null,
+        mixed $files,
         /** The ID of the channel that this file will be uploaded to */
         string $channel_id,
         /** A unique identifier for the file that will be returned in the response */

--- a/src/Client/MultipartTrait.php
+++ b/src/Client/MultipartTrait.php
@@ -27,7 +27,7 @@ trait MultipartTrait
             }
 
             if (is_array($value) && isset($value['contents'])) {
-                $elements[] = array_merge(['name' => $name], $value);
+                $elements[] = $value;
             } else {
                 $elements[] = [
                     'name' => $name,

--- a/test/Client/Endpoint/FilesEndpointTest.php
+++ b/test/Client/Endpoint/FilesEndpointTest.php
@@ -44,7 +44,7 @@ class FilesEndpointTest extends ClientTestCase
         $client_ids = 'test-client_ids';
         $filename = 'test-filename';
 
-        $result = $this->endpoint->uploadFile($files, $channel_id, $client_ids, $filename);
+        $result = $this->endpoint->uploadFile($filename, $files, $channel_id, $client_ids);
 
         $this->assertNotNull($this->getLastRequest());
         $this->assertRequestMethod('POST');


### PR DESCRIPTION
Add correct filename and extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart uploads no longer inject unintended keys into file/field parts, fixing malformed multipart payloads.

* **New Features / UX**
  * File upload now requires an explicit filename up-front and always includes both the provided filename and a derived file name for uploaded files.
  * Uploads now require a channel identifier to be supplied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->